### PR TITLE
ループ時の空白文字結合をサイズ確認前に実行

### DIFF
--- a/hunbwalt_der_unko.rb
+++ b/hunbwalt_der_unko.rb
@@ -35,12 +35,11 @@ Plugin.create(:hunbwalt_der_unko) do
   end
 
   on_der_unko do |message|
-    msg = '@' + message.user.idname + ' '
+    msg = '@' + message.user.idname
     loop do
-      n_msg = greets.sample
+      n_msg =  ' ' + greets.sample
       break if msg.size + n_msg.size >= 140
-
-      msg += n_msg + ' '
+      msg += n_msg
     end
     world, = Plugin.filtering(:world_current, nil)
     compose(world, message, body: msg)


### PR DESCRIPTION
この変更によってsize評価後に空白文字を入れる処理よりもループが少なくなる場合がある
msg.size + n_msg.size == 139 の場合、次のループで必ずbreakする
評価前に空白文字を入れることで次のループに行くことなくbreakする
単純計算で一人当たり年間1万回実行するとして、10人のmikutterユーザーが実行した場合に10万回分のループを節約できることになる